### PR TITLE
Change 'File.from_path' to 'resolve_url_to_file'

### DIFF
--- a/bin/workflows/pycbc_make_sbank_workflow
+++ b/bin/workflows/pycbc_make_sbank_workflow
@@ -202,7 +202,7 @@ if workflow.cp.has_option_tags('workflow', 'seed-bank', args.tags):
         # NOTE: Be careful that the seed-file will not exist when the
         #       dax file is generated if this is a sub-workflow.
         #       Don't run anything that assumes it will be there
-        seed_file = wf.File.from_path(seed_bank, store_file=False)
+        seed_file = wf.resolve_url_to_file(seed_bank)
         seed_files.append(seed_file)
     if len(seed_files) == 1:
         seed_file = seed_files[0]


### PR DESCRIPTION
The purpose of this PR is to change 'File.from_path' to 'resolve_url_to_file' to fix the following error when running `pycbc_make_sbank_workflow`:

```bash
2023.01.13 01:52:00.739 PST: [FATAL ERROR]  java.lang.RuntimeException: TransferEngine.java: Can't determine a location to transfer input file for lfn PREC_BANK_RUN1.h5 for job sbank_mchirp_bins_ID0_ID0000001
```

This change was suggested from @spxiwh and follows similar syntax to [pycbc_make_uberbank_workflow](https://github.com/gwastro/pycbc/blob/55c7233d282bab0b819c3de9e7f936d5271446f2/bin/workflows/pycbc_make_uberbank_workflow#L162)